### PR TITLE
Adding CBS

### DIFF
--- a/Config/siteInfo.js
+++ b/Config/siteInfo.js
@@ -7,6 +7,10 @@ module.exports = {
 		name: 'Breitbart',
 		url: 'http://www.breitbart.com' 
 	},
+	cbs: {
+		name: 'CBS News',
+		url: 'https://www.cbsnews.com'
+	},
 	dailyCaller: {
 		name: 'The Daily Caller',
 		url: 'http://www.dailycaller.com'
@@ -26,6 +30,10 @@ module.exports = {
 	nyt: {
 		name: 'New York Times',
 		url: 'https://www.nytimes.com'
+	},
+	politico: {
+		name: 'Politico',
+		url: 'http://www.politico.com'
 	},
 	reuters: {
 		name: 'Reuters',
@@ -54,9 +62,5 @@ module.exports = {
 	wsj: {
 		name: 'Wall Street Journal',
 		url: 'http://www.wsj.com'
-	},
-	politico: {
-		name: 'Politico',
-		url: 'http://www.politico.com'
 	}
 };

--- a/createPayload.js
+++ b/createPayload.js
@@ -2,17 +2,20 @@ var R = require('ramda');
 
 var configureUrl = R.curry((siteUrl, hasLink, link) => { return link.includes(siteUrl) || hasLink ? link : siteUrl + link;});
 
-module.exports = (obj) => {
-	return R.tryCatch(R.compose(
-									R.objOf(obj.name),
-									R.evolve({articleLink: configureUrl(obj.url,obj.link)}),
-									(obj) => {
-										return {
-											articleLink: obj.link ? obj.link : obj.node.attr('href'),
-											articleTitle: obj.text ? obj.text : obj.node.text(),
-											siteUrl: obj.url
-										};
-									}
-								),R.always({}))(obj) ;
+var formatArticleLink = (siteUrl, link) => {
+	return (link.indexOf(siteUrl) >= 0 || link.indexOf('http') >= 0) ? link : `${siteUrl}${link}`;
 };
 
+module.exports = (obj) => {
+	return R.tryCatch(R.compose(
+		R.objOf(obj.name),
+		R.evolve({articleLink: configureUrl(obj.url,obj.link)}),
+		(obj) => {
+			return {
+				articleLink: formatArticleLink(obj.url, obj.link),
+				articleTitle: obj.text ? obj.text : obj.node.text(),
+				siteUrl: obj.url
+			};
+		}
+	),R.always({}))(obj);
+};

--- a/index.js
+++ b/index.js
@@ -14,12 +14,14 @@ var	brietbart = require('./Sites/breitbart'),
 	wsj = require('./Sites/wjs'),
 	vox = require('./Sites/vox'),
 	washPo = require('./Sites/washPo'),
-	politico = require('./Sites/politico');
+	politico = require('./Sites/politico'),
+	cbs = require('./Sites/cbs');
 
 var promises = [
 	// ap,
 	blaze,
-	brietbart, 
+	brietbart,
+	cbs,
 	dailyCaller,
 	drudge,
 	economist,


### PR DESCRIPTION
We need the formatArticleLink function to prevent some links from coming back like this:

`'The Economist': 
   { articleLink: '/news/leaders/21736517-should-be-cause-celebration-or-concern-mega-rich-have-ambitious-plans-improve',
     articleTitle: 'The mega-rich have ambitious plans to improve the world',
     siteUrl: 'https://www.economist.com' },`

while others look like this (correct):

`'New York Times': 
   { articleLink: 'https://www.nytimes.com/2018/02/11/us/politics/nancy-pelosi-democrats-immigration.html',
     articleTitle: 'Pelosi Wants to Win House, but Can She Corral the Democrats?',
     siteUrl: 'https://www.nytimes.com' },`

This will make sure that the articleLink always starts with the name of the website. Or, in the case of Drudge, who likes to link to external sites, the full link stays intact.